### PR TITLE
chore: tsreadex aud1 to 12, aud2 to 4

### DIFF
--- a/libvlc/patches/9015-feat-Add-arib_dualmono-stream-filter.patch
+++ b/libvlc/patches/9015-feat-Add-arib_dualmono-stream-filter.patch
@@ -1,4 +1,4 @@
-From 3d984fce7917e99faba04690f94c9aad8d7b95d3 Mon Sep 17 00:00:00 2001
+From d7ebf80acaa46cb22070e7113a23f9a25c71dec6 Mon Sep 17 00:00:00 2001
 From: ci7lus <7887955+ci7lus@users.noreply.github.com>
 Date: Sat, 21 Feb 2026 21:23:20 +0900
 Subject: [PATCH 1/3] feat: Add arib_dualmono stream filter
@@ -8,9 +8,9 @@ Subject: [PATCH 1/3] feat: Add arib_dualmono stream filter
  contrib/src/tsreadex/rules.mak                |  24 ++
  modules/demux/mpeg/ts_psi.c                   |  15 ++
  modules/stream_filter/Makefile.am             |   5 +
- .../arib_dualmono/arib_dualmono.cpp           | 209 ++++++++++++++++++
+ .../arib_dualmono/arib_dualmono.cpp           | 211 ++++++++++++++++++
  modules/stream_filter/meson.build             |   8 +
- 6 files changed, 262 insertions(+)
+ 6 files changed, 264 insertions(+)
  create mode 100644 contrib/src/tsreadex/SHA512SUMS
  create mode 100644 contrib/src/tsreadex/rules.mak
  create mode 100644 modules/stream_filter/arib_dualmono/arib_dualmono.cpp
@@ -93,10 +93,10 @@ index 1d6a5499b2..aa14a96201 100644
 +stream_filter_LTLIBRARIES += libarib_dualmono_plugin.la
 diff --git a/modules/stream_filter/arib_dualmono/arib_dualmono.cpp b/modules/stream_filter/arib_dualmono/arib_dualmono.cpp
 new file mode 100644
-index 0000000000..da433587cb
+index 0000000000..0e069cd4b2
 --- /dev/null
 +++ b/modules/stream_filter/arib_dualmono/arib_dualmono.cpp
-@@ -0,0 +1,209 @@
+@@ -0,0 +1,211 @@
 +/*****************************************************************************
 + * arib_dualmono.cpp : ARIB DualMono audio separator stream filter
 + *****************************************************************************/
@@ -284,8 +284,10 @@ index 0000000000..da433587cb
 +    // Process the first program found in PAT instead of skipping (passthrough mode)
 +    p_sys->p_filter->SetProgramNumberOrIndex(-1);
 +
-+    // Set audio1 mode to 8 (+8 activates TransmuxDualMono in tsreadex logic)
-+    p_sys->p_filter->SetAudio1Mode(8);
++    // Set audio1 mode to 12 (+4 mono to stereo, +8 activates TransmuxDualMono in tsreadex logic)
++    p_sys->p_filter->SetAudio1Mode(12);
++    // Set audio2 mode to 4 (+4 mono to stereo)
++    p_sys->p_filter->SetAudio2Mode(4);
 +
 +    msg_Dbg(p_stream, "ARIB DualMono filter initialized (tsreadex processing enabled)");
 +


### PR DESCRIPTION
VLC 4.0.0のaac decoderはstereo -> monoでおかしくなるので、+4もします