### PR TITLE
fix: libaribcaption rendering size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./Packaging/create-distributable-package.sh -x -d
         shell: bash
       - name: Build (Full)
-        if: ${{ github.event_name != 'pull_request' }}
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event.inputs.release == 'true'
         run: ./Packaging/create-distributable-package.sh -x -m -d
         shell: bash
       - name: Upload
@@ -34,14 +34,14 @@ jobs:
           path: "*.dmg"
           archive: false
       - name: Get current time
-        if: ${{ github.event.inputs.release }}
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event.inputs.release == 'true'
         uses: josStorer/get-current-time@v2
         id: time
         with:
           format: "YYYYMMDDHHmm"
           utcOffset: "+09:00"
       - name: Release
-        if: ${{ github.event.inputs.release }}
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event.inputs.release == 'true'
         uses: softprops/action-gh-release@v2
         with:
           files: "*.dmg"

--- a/libvlc/patches/9011-fix-Fallback-to-software-rendering-when-screenshot-c.patch
+++ b/libvlc/patches/9011-fix-Fallback-to-software-rendering-when-screenshot-c.patch
@@ -1,15 +1,15 @@
-From abecf408b50bc93df4cd1a04f64484ab9539f77b Mon Sep 17 00:00:00 2001
+From b0c0fe6992d68fe74d6aa9e279573ad474a0853a Mon Sep 17 00:00:00 2001
 From: ci7lus <7887955+ci7lus@users.noreply.github.com>
 Date: Wed, 18 Feb 2026 00:55:23 +0900
-Subject: [PATCH 9011/9014] fix: Fallback to software rendering when screenshot
+Subject: [PATCH 01/11] fix: Fallback to software rendering when screenshot
  capture fails
 
 ---
- src/video_output/video_output.c | 58 +++++++++++++++++++++++++++++++--
- 1 file changed, 55 insertions(+), 3 deletions(-)
+ src/video_output/video_output.c | 118 ++++++++++++++++++++++++--------
+ 1 file changed, 91 insertions(+), 27 deletions(-)
 
 diff --git a/src/video_output/video_output.c b/src/video_output/video_output.c
-index 0ec4d219ab..bd075b13df 100644
+index 0ec4d219ab..e7331eb466 100644
 --- a/src/video_output/video_output.c
 +++ b/src/video_output/video_output.c
 @@ -407,6 +407,47 @@ void vout_PutPicture(vout_thread_t *vout, picture_t *picture)
@@ -84,6 +84,93 @@ index 0ec4d219ab..bd075b13df 100644
              msg_Err(vout, "Failed to convert image for snapshot");
              picture_Release(picture);
              return VLC_EGENERIC;
+@@ -1158,13 +1210,20 @@ static picture_t *ConvertRGBAAndBlend(vout_thread_sys_t *vout, picture_t *pic,
+                                       vlc_render_subpicture *subpic)
+ {
+     vout_thread_sys_t *sys = vout;
+-    /* This function will convert the pic to RGBA and blend the subpic to it.
++    /* This function will convert the pic to a software format and blend the subpic to it.
+      * The returned pic can't be used to display since the chroma will be
+      * different than the "vout display" one, but it can be used for snapshots.
+      * */
+ 
+     assert(sys->spu_blend);
+ 
++    static const vlc_fourcc_t candidates[] = {
++        VLC_CODEC_I420,
++        VLC_CODEC_NV12,
++        VLC_CODEC_RGB24,
++        VLC_CODEC_RGBA,
++    };
++
+     filter_owner_t owner = {
+         .video = &vout_video_cbs,
+         .sys = vout,
+@@ -1174,36 +1233,41 @@ static picture_t *ConvertRGBAAndBlend(vout_thread_sys_t *vout, picture_t *pic,
+         return NULL;
+ 
+     es_format_t src = sys->spu_blend->fmt_out;
+-    es_format_t dst = src;
+-    dst.video.i_chroma = VLC_CODEC_RGBA;
++    picture_t *converted = NULL;
+ 
+-    filter_chain_Reset(filterc, &src,
+-                       NULL /* TODO output video context of blender */,
+-                       &dst);
+-
+-    if (filter_chain_AppendConverter(filterc, &dst) != VLC_SUCCESS)
++    for (size_t i = 0; i < ARRAY_SIZE(candidates) && converted == NULL; ++i)
+     {
+-        filter_chain_Delete(filterc);
+-        return NULL;
+-    }
++        es_format_t dst = src;
++        dst.i_codec = candidates[i];
++        dst.video.i_chroma = candidates[i];
+ 
+-    picture_Hold(pic);
+-    pic = filter_chain_VideoFilter(filterc, pic);
+-    filter_chain_Delete(filterc);
++        filter_chain_Reset(filterc, &src,
++                           picture_GetVideoContext(pic),
++                           &dst);
+ 
+-    if (pic)
+-    {
+-        vlc_blender_t *swblend = filter_NewBlend(VLC_OBJECT(&vout->obj), &dst.video);
+-        if (swblend)
++        if (filter_chain_AppendConverter(filterc, &dst) != VLC_SUCCESS)
++            continue;
++
++        picture_Hold(pic);
++        converted = filter_chain_VideoFilter(filterc, pic);
++
++        if (converted)
+         {
+-            bool success = picture_BlendSubpicture(pic, swblend, subpic) > 0;
+-            filter_DeleteBlend(swblend);
+-            if (success)
+-                return pic;
++            vlc_blender_t *swblend = filter_NewBlend(VLC_OBJECT(&vout->obj), &dst.video);
++            if (swblend)
++            {
++                bool success = picture_BlendSubpicture(converted, swblend, subpic) > 0;
++                filter_DeleteBlend(swblend);
++                if (success)
++                    break;
++            }
++            picture_Release(converted);
++            converted = NULL;
+         }
+-        picture_Release(pic);
+     }
+-    return NULL;
++
++    filter_chain_Delete(filterc);
++    return converted;
+ }
+ 
+ static picture_t *FilterPictureInteractive(vout_thread_sys_t *sys)
 -- 
 2.39.1
 

--- a/libvlc/patches/9021-libaribcaption-fix-caption-rendering-size.patch
+++ b/libvlc/patches/9021-libaribcaption-fix-caption-rendering-size.patch
@@ -1,0 +1,40 @@
+From dc7bbab80a480e8ec41b6a22f25eb35cc73ac3d7 Mon Sep 17 00:00:00 2001
+From: ci7lus <7887955+ci7lus@users.noreply.github.com>
+Date: Mon, 6 Apr 2026 20:04:54 +0900
+Subject: [PATCH] libaribcaption: fix caption rendering size
+
+---
+ modules/codec/arib/libaribcaption.c | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/modules/codec/arib/libaribcaption.c b/modules/codec/arib/libaribcaption.c
+index 0bf9a6228d..774a225e1a 100644
+--- a/modules/codec/arib/libaribcaption.c
++++ b/modules/codec/arib/libaribcaption.c
+@@ -121,12 +121,19 @@ static void SubpictureUpdate(subpicture_t *p_subpic,
+     const video_format_t *p_dst_format = cfg->video_dst;
+ 
+     bool b_src_changed = p_src_format->i_visible_width  != cfg->prev_src->i_visible_width ||
+-                         p_src_format->i_visible_height != cfg->prev_src->i_visible_height;
++                         p_src_format->i_visible_height != cfg->prev_src->i_visible_height ||
++                         p_src_format->i_sar_num != cfg->prev_src->i_sar_num ||
++                         p_src_format->i_sar_den != cfg->prev_src->i_sar_den;
+     bool b_dst_changed = !video_format_IsSimilar(cfg->prev_dst, p_dst_format);
+ 
+-    unsigned i_render_area_width  = p_dst_format->i_visible_width;
+-    unsigned i_render_area_height = p_src_format->i_visible_height * p_dst_format->i_visible_width /
+-                                    p_src_format->i_visible_width;
++    unsigned i_sar_num = p_src_format->i_sar_num > 0 ? p_src_format->i_sar_num : 1;
++    unsigned i_sar_den = p_src_format->i_sar_den > 0 ? p_src_format->i_sar_den : 1;
++
++    unsigned i_render_area_height = p_dst_format->i_visible_height & ~3;
++    unsigned i_render_area_width = (uint64_t)i_render_area_height *
++                                   p_src_format->i_visible_width * i_sar_num /
++                                   (p_src_format->i_visible_height * i_sar_den) & ~3;
++
+     if (b_src_changed || b_dst_changed) {
+         /* don't let library freely scale using either the min of width or height ratio */
+         vlc_mutex_lock(&p_sys->aribcc_lock);
+-- 
+2.39.1
+


### PR DESCRIPTION
#37 のだし直し

- `1440*1080` の映像ソースにおいてlibaribcaption字幕が小さくなってしまう現象を修正します
- hevcソースにおいてスナップショットに字幕が乗らない現象を修正します