### PR TITLE
fix: add patch to fix black screen upon returning to foreground for iOS

### DIFF
--- a/libvlc/patches/9026-apple-fix-AVSampleBufferDisplayLayer-failing-to-resu.patch
+++ b/libvlc/patches/9026-apple-fix-AVSampleBufferDisplayLayer-failing-to-resu.patch
@@ -1,0 +1,28 @@
+From 5fb7d3acb58f7ee52401c36f3938283050f6a567 Mon Sep 17 00:00:00 2001
+From: ci7lus <7887955+ci7lus@users.noreply.github.com>
+Date: Sun, 17 May 2026 16:09:35 +0900
+Subject: [PATCH] apple: fix AVSampleBufferDisplayLayer failing to resume from
+ background
+
+When returning to the foreground, AVSampleBufferDisplayLayer's status may be AVQueuedSampleBufferRenderingStatusFailed, causing it to drop all newly enqueued buffers. Call flushAndRemoveImage to recover.
+---
+ modules/video_output/apple/VLCSampleBufferDisplay.m | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/modules/video_output/apple/VLCSampleBufferDisplay.m b/modules/video_output/apple/VLCSampleBufferDisplay.m
+index 27e23da0316..fb257254d01 100644
+--- a/modules/video_output/apple/VLCSampleBufferDisplay.m
++++ b/modules/video_output/apple/VLCSampleBufferDisplay.m
+@@ -916,6 +916,9 @@ static void RenderPicture(vout_display_t *vd, picture_t *pic, vlc_tick_t date) {
+     }
+ 
+     @synchronized(sys.displayLayer) {
++        if (sys.displayLayer.status == AVQueuedSampleBufferRenderingStatusFailed) {
++            [sys.displayLayer flushAndRemoveImage];
++        }
+         [sys.displayLayer enqueueSampleBuffer:sampleBuffer];
+     }
+ 
+-- 
+2.39.1
+


### PR DESCRIPTION
再生を止めてバックグラウンドから復帰したときに黒画面から戻らない不具合を修正します。