### PR TITLE
chore: Update ref (demux/mpeg: Improve non-fastseek time seeking)

### DIFF
--- a/Headers/Public/Media/VLCMedia.h
+++ b/Headers/Public/Media/VLCMedia.h
@@ -519,6 +519,11 @@ NS_SWIFT_NAME(VLCMedia.AudioTrack)
  */
 @property(nonatomic, readonly) unsigned rate;
 
+/**
+ * Whether the audio track is currently carrying dual-mono audio.
+ */
+@property(nonatomic, readonly, getter=isDualMono) BOOL dualMono;
+
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;

--- a/Sources/Media/VLCMedia.m
+++ b/Sources/Media/VLCMedia.m
@@ -833,12 +833,13 @@ static const struct event_handler_entry {
         return nil;
     _channelsNumber = audio->i_channels;
     _rate = audio->i_rate;
+    _dualMono = audio->b_dual_mono;
     return self;
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p>, channelsNumber: %d, rate: %d", [self class], self, _channelsNumber, _rate];
+    return [NSString stringWithFormat:@"<%@ %p>, channelsNumber: %d, rate: %d, dualMono: %@", [self class], self, _channelsNumber, _rate, _dualMono ? @"YES" : @"NO"];
 }
 
 @end

--- a/compileAndBuildVLCKit.sh
+++ b/compileAndBuildVLCKit.sh
@@ -31,7 +31,7 @@ if [ -z "$MAKEFLAGS" ]; then
 fi
 
 BRANCH="master"
-TESTEDHASH="9e411c576e0ed8b0c5aca760c3804382d0ccd0c6" # libvlc hash that this version of VLCKit is build on
+TESTEDHASH="3f756b724a38768df9837bffe5f75a07c890d155" # libvlc hash that this version of VLCKit is build on
 
 usage()
 {


### PR DESCRIPTION
#53 でシーク挙動は直ったものの、返されるpositionがおかしくなっていました

シークバーでの挙動を考えて返すpositionを時刻ベースからbytesベースに統一していましたが、upstreamとの差分が大きくなりすぎる上に理想挙動の実現が難しいので、時刻ベースに戻しています
ただ、時刻移動する際の精度を改善しています。近傍に移動する際は高めの精度で移動できます

修正の一環でarib_dualmono(tsreadex)を削除しています