### PR TITLE
VLCMediaPlayer: add bytePosition property

### DIFF
--- a/Headers/Public/Playback/VLCMediaPlayer.h
+++ b/Headers/Public/Playback/VLCMediaPlayer.h
@@ -944,6 +944,17 @@ typedef NS_ENUM(unsigned, VLCAudioMixMode)
 @property (NS_NONATOMIC_IOSONLY) double position;
 
 /**
+ * Returns the receiver's byte-offset position.
+ *
+ * Unlike \c position, this returns the raw stream byte offset as a
+ * fraction of the total stream size, without timer interpolation.
+ * Suitable for saving and restoring exact playback positions.
+ *
+ * \return byte position as percentage between 0.0 and 1.0.
+ */
+@property (NS_NONATOMIC_IOSONLY, readonly) double bytePosition;
+
+/**
  * property whether the current input is seekable or not, e.g. it's a live stream
  * \note Setting position or time for non-seekable inputs does not have any effect and will fail silently
  * \return BOOL value

--- a/Sources/Playback/VLCMediaPlayer.m
+++ b/Sources/Playback/VLCMediaPlayer.m
@@ -1694,6 +1694,11 @@ static void HandleMediaPlayerPreviousFrameStatus(void *opaque, int status)
     libvlc_media_player_set_position(_playerInstance, newPosition, NO);
 }
 
+- (double)bytePosition
+{
+    return libvlc_media_player_get_byte_position(_playerInstance);
+}
+
 - (BOOL)isSeeking
 {
     __block BOOL isSeeking = NO;

--- a/compileAndBuildVLCKit.sh
+++ b/compileAndBuildVLCKit.sh
@@ -31,7 +31,7 @@ if [ -z "$MAKEFLAGS" ]; then
 fi
 
 BRANCH="master20260717"
-TESTEDHASH="7dc90a844c4a1231eca0c7e82bef058c0c63f506" # libvlc hash that this version of VLCKit is build on
+TESTEDHASH="d136eeeba4bfef5a7fdd318b5ea743f1daba6dae" # libvlc hash that this version of VLCKit is build on
 
 usage()
 {


### PR DESCRIPTION
再シークしたときの補正をやるのと、バイトベースのpositionであるbytePositionを取得する口を追加します